### PR TITLE
Fix diff algorithm

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/main/scala/gnieh/diffson/DynamicProgLcs.scala
+++ b/src/main/scala/gnieh/diffson/DynamicProgLcs.scala
@@ -1,0 +1,74 @@
+package gnieh.diffson
+
+import scala.annotation.tailrec
+
+/** Implementation of the LCS using dynamic programming.
+ *
+ *  @author Lucas Satabin
+ */
+class DynamicProgLcs[T] extends Lcs[T] {
+
+  def lcs(s1: Seq[T], s2: Seq[T], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)] = {
+    val seq1 = s1.slice(low1, high1)
+    val seq2 = s2.slice(low2, high2)
+    if (seq1.isEmpty || seq2.isEmpty) {
+      // shortcut if at least on sequence is empty, the lcs, is empty as well
+      Nil
+    } else if (seq1 == seq2) {
+      // both sequences are equal, the lcs is either of them
+      seq1.indices.map(i => (i + low1, i + low2)).toList
+    } else if (seq1.startsWith(seq2)) {
+      // the second sequence is a prefix of the first one
+      // the lcs is the second sequence
+      seq2.indices.map(i => (i + low1, i + low2)).toList
+    } else if (seq2.startsWith(seq1)) {
+      // the first sequence is a prefix of the second one
+      // the lcs is the first sequence
+      seq1.indices.map(i => (i + low1, i + low2)).toList
+    } else {
+      // we try to reduce the problem by stripping common suffix and prefix
+      val (prefix, middle1, middle2, suffix) = splitPrefixSuffix(seq1, seq2, low1, low2)
+      val offset = prefix.size
+      val lengths = Array.ofDim[Int](middle1.size + 1, middle2.size + 1)
+      // fill up the length matrix
+      for {
+        i <- 0 until middle1.size
+        j <- 0 until middle2.size
+      } if (middle1(i) == middle2(j))
+        lengths(i + 1)(j + 1) = lengths(i)(j) + 1
+      else
+        lengths(i + 1)(j + 1) = math.max(lengths(i + 1)(j), lengths(i)(j + 1))
+      // and compute the lcs out of the matrix
+      @tailrec
+      def loop(idx1: Int, idx2: Int, acc: List[(Int, Int)]): List[(Int, Int)] =
+        if (idx1 == 0 || idx2 == 0) {
+          acc
+        } else if (lengths(idx1)(idx2) == lengths(idx1 - 1)(idx2)) {
+          loop(idx1 - 1, idx2, acc)
+        } else if (lengths(idx1)(idx2) == lengths(idx1)(idx2 - 1)) {
+          loop(idx1, idx2 - 1, acc)
+        } else {
+          assert(seq1(offset + idx1 - 1) == seq2(offset + idx2 - 1))
+          loop(idx1 - 1, idx2 - 1, (low1 + offset + idx1 - 1, low2 + offset + idx2 - 1) :: acc)
+        }
+
+      prefix ++ loop(middle1.size, middle2.size, Nil) ++ suffix
+    }
+  }
+
+  /* Extract common prefix and suffix from both sequences */
+  private def splitPrefixSuffix(seq1: Seq[T], seq2: Seq[T], low1: Int, low2: Int): (List[(Int, Int)], Seq[T], Seq[T], List[(Int, Int)]) = {
+    val size1 = seq1.size
+    val size2 = seq2.size
+    val prefix =
+      seq1.zip(seq2).takeWhile {
+        case (e1, e2) => e1 == e2
+      }.indices.map(i => (i + low1, i + low2)).toList
+    val suffix =
+      seq1.reverse.zip(seq2.reverse).takeWhile {
+        case (e1, e2) => e1 == e2
+      }.indices.map(i => (size1 - i - 1 + low1, size2 - i - 1 + low2)).toList.reverse
+    (prefix, seq1.drop(prefix.size).dropRight(suffix.size), seq2.drop(prefix.size).dropRight(suffix.size), suffix)
+  }
+
+}

--- a/src/main/scala/gnieh/diffson/Lcs.scala
+++ b/src/main/scala/gnieh/diffson/Lcs.scala
@@ -23,8 +23,15 @@ package gnieh.diffson
 trait Lcs[T] {
 
   /** Computes the longest commons subsequence between both inputs.
-   *  Returns an ordered list containing the indices in the first sequence and in the second sequence */
-  def lcs(seq1: Seq[T], seq2: Seq[T]): List[(Int, Int)]
+   *  Returns an ordered list containing the indices in the first sequence and in the second sequence.
+   */
+  def lcs(seq1: Seq[T], seq2: Seq[T]): List[(Int, Int)] =
+    lcs(seq1, seq2, 0, seq1.size, 0, seq2.size)
+
+  /** Computest the longest common subsequence between both input slices.
+   *  Returns an ordered list containing the indices in the first sequence and in the second sequence.
+   */
+  def lcs(seq1: Seq[T], seq2: Seq[T], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)]
 
 }
 

--- a/src/main/scala/gnieh/diffson/Patience.scala
+++ b/src/main/scala/gnieh/diffson/Patience.scala
@@ -21,8 +21,14 @@ import scala.annotation.tailrec
  *
  *  [1] http://alfedenzo.livejournal.com/170301.html
  *
- *  @author Lucas Satabin */
-class Patience[T] extends Lcs[T] {
+ *  @param withFallback whether to fallback to classic LCS when patience could not find the LCS
+ *  @author Lucas Satabin
+ */
+class Patience[T](withFallback: Boolean = true) extends Lcs[T] {
+
+  // algorithm we fall back to when patience algorithm is unable to find the LCS
+  private val classicLcs =
+    if (withFallback) Some(new DynamicProgLcs[T]) else None
 
   /** An occurrence of a value associated to its index */
   type Occurrence = (T, Int)
@@ -32,7 +38,7 @@ class Patience[T] extends Lcs[T] {
     @tailrec
     def loop(l: List[Occurrence], acc: Map[T, Int]): List[Occurrence] = l match {
       case (value, idx) :: tl =>
-        if(acc.contains(value))
+        if (acc.contains(value))
           // not unique, remove it from the accumulator and go further
           loop(tl, acc - value)
         else
@@ -51,7 +57,7 @@ class Patience[T] extends Lcs[T] {
         // find the element in the second sequence if present
         l2.find(_._1 == occ._1) match {
           case Some((_, idx2)) => loop(tl, (occ -> idx2) :: acc)
-          case None          => loop(tl, acc)
+          case None            => loop(tl, acc)
         }
       case Nil =>
         // sort by order of appearance in the second sequence
@@ -72,7 +78,7 @@ class Patience[T] extends Lcs[T] {
 
   /** Returns the longest sequence */
   private def longest(l: List[(Occurrence, Int)]): List[(Int, Int)] = {
-    if(l.isEmpty) {
+    if (l.isEmpty) {
       Nil
     } else {
       @tailrec
@@ -91,8 +97,9 @@ class Patience[T] extends Lcs[T] {
           throw new Exception("No empty stack must exist")
       }
       def sort(l: List[(Occurrence, Int)]): List[List[Stacked]] =
-        l.foldLeft(List[List[Stacked]]()) { case (acc, ((_, idx1), idx2)) =>
-          push(idx1, idx2, acc, None, Nil)
+        l.foldLeft(List[List[Stacked]]()) {
+          case (acc, ((_, idx1), idx2)) =>
+            push(idx1, idx2, acc, None, Nil)
         }
       val sorted = sort(l)
       // this call is safe as we know that the list of occurrence is not empty here and that there are no empty stacks
@@ -105,48 +112,87 @@ class Patience[T] extends Lcs[T] {
   /** Computes the longest common subsequence between both sequences.
    *  It is encoded as the list of common indices in the first and the second sequence.
    */
-  def lcs(seq1: Seq[T], seq2: Seq[T]): List[(Int, Int)] =
-    if(seq1.isEmpty || seq2.isEmpty) {
+  def lcs(s1: Seq[T], s2: Seq[T], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)] = {
+    val seq1 = s1.slice(low1, high1)
+    val seq2 = s2.slice(low2, high2)
+    if (seq1.isEmpty || seq2.isEmpty) {
       // shortcut if at least on sequence is empty, the lcs, is empty as well
       Nil
-    } else if(seq1 == seq2) {
+    } else if (seq1 == seq2) {
       // both sequences are equal, the lcs is either of them
-      seq1.indices.map(i => (i, i)).toList
-    } else if(seq1.startsWith(seq2)) {
+      seq1.indices.map(i => (i + low1, i + low2)).toList
+    } else if (seq1.startsWith(seq2)) {
       // the second sequence is a prefix of the first one
       // the lcs is the second sequence
-      seq2.indices.map(i => (i, i)).toList
-    } else if(seq2.startsWith(seq1)) {
+      seq2.indices.map(i => (i + low1, i + low2)).toList
+    } else if (seq2.startsWith(seq1)) {
       // the first sequence is a prefix of the second one
       // the lcs is the first sequence
-      seq1.indices.map(i => (i, i)).toList
+      seq1.indices.map(i => (i + low1, i + low2)).toList
     } else {
-      // the lcs of common elements that appear only once in each sequence
-      val longestUniques = longest(uniqueCommons(seq1, seq2))
       // fill the holes with possibly common (not unique) elements
-      @tailrec
-      def loop(longestUniques: List[(Int, Int)], currIdx1: Int, currIdx2: Int, acc: List[(Int, Int)]): List[(Int, Int)] = longestUniques match {
-        case (idx1, idx2) :: tl if idx1 <= currIdx1 || idx2 <= currIdx2 =>
-          // we reached one upper bound
-          loop(tl, idx1 + 1, idx2 + 1, (idx1, idx2) :: acc)
-        case l @ ((idx1, idx2) :: _) if idx1 > currIdx1 && idx2 > currIdx2 =>
-          // if this is a non unique common element add it to accumulator
-          if(seq1(currIdx1) == seq2(currIdx2)) {
-            loop(l, currIdx1 + 1, currIdx2 + 1, (currIdx1, currIdx2) :: acc)
-          } else {
-            loop(l, currIdx1, currIdx2 + 1, acc)
+      def loop(low1: Int, low2: Int, high1: Int, high2: Int, acc: List[(Int, Int)]): List[(Int, Int)] =
+        if (low1 == high1 || low2 == high2) {
+          acc
+        } else {
+          var lastPos1 = low1 - 1
+          var lastPos2 = low2 - 1
+          var answer = acc
+          for ((p1, p2) <- longest(uniqueCommons(seq1.view(low1, high1), seq2.view(low2, high2)))) {
+            // recurse between lines which are unique in each sequence
+            val pos1 = p1 + low1
+            val pos2 = p2 + low2
+            // most of the time we have sequences of similar entries
+            if (lastPos1 + 1 != pos1 || lastPos2 + 1 != pos2)
+              answer = loop(lastPos1 + 1, lastPos2 + 1, pos1, pos2, answer)
+            lastPos1 = pos1
+            lastPos2 = pos2
+            answer = (pos1, pos2) :: answer
           }
-        case Nil =>
-          acc.reverse
-        case _ =>
-          // due to a bug in pattern matcher, the compiler complains about not exhaustive match
-          // though it is
-          throw new Exception("This case should NEVER happen")
+          if (answer.size > acc.size) {
+            // the size of the accumulator increased, find
+            // matches between the last match and the end
+            loop(lastPos1 + 1, lastPos2 + 1, high1, high2, answer)
+          } else if (seq1(low1) == seq2(low2)) {
+            // find lines that match at the beginning
+            var newLow1 = low1
+            var newLow2 = low2
+            while (newLow1 < high1 && newLow2 < high2 && seq1(newLow1) == seq2(newLow2)) {
+              answer = (newLow1, newLow2) :: answer
+              newLow1 += 1
+              newLow2 += 1
+            }
+            loop(newLow1, newLow2, high1, high2, answer)
+          } else if (seq1(high1 - 1) == seq2(high2 - 1)) {
+            // find lines that match at the end
+            var newHigh1 = high1 - 1
+            var newHigh2 = high2 - 1
+            while (newHigh1 > low1 && newHigh2 > low2 && seq1(newHigh1 - 1) == seq2(newHigh2 - 1)) {
+              newHigh1 -= 1
+              newHigh2 -= 1
+            }
+            answer = loop(lastPos1 + 1, lastPos2 + 1, newHigh1, newHigh2, answer)
+            for (i <- 0 until (high1 - newHigh1))
+              answer = (newHigh1 + i, newHigh2 + i) :: answer
+            answer
+          } else {
+            classicLcs match {
+              case Some(classicLcs) =>
+                // fall back to classic LCS algorithm when there is no unique common elements
+                // between both sequences and they have no common prefix nor suffix
+                // raw patience algorithm is not good for finding LCS in such cases
+                classicLcs.lcs(seq1, seq2, low1, high1, low2, high2) reverse_::: answer
 
-      }
+              case _ =>
+                answer
+            }
+          }
+
+        }
       // we start with first indices in both sequences
-      loop(longestUniques, 0, 0, Nil)
+      loop(low1, low2, high1, high2, Nil).reverse
     }
+  }
 
 }
 

--- a/src/test/scala/gnieh/diffson/TestDynLcs.scala
+++ b/src/test/scala/gnieh/diffson/TestDynLcs.scala
@@ -1,0 +1,10 @@
+package gnieh.diffson
+package test
+
+import org.scalatest._
+
+class TestDynLcs extends TestLcs {
+
+  val lcsImpl = new DynamicProgLcs[Char]
+
+}

--- a/src/test/scala/gnieh/diffson/TestLcs.scala
+++ b/src/test/scala/gnieh/diffson/TestLcs.scala
@@ -1,0 +1,95 @@
+package gnieh.diffson
+package test
+
+import org.scalatest._
+
+abstract class TestLcs extends FlatSpec with ShouldMatchers {
+
+  val lcsImpl: Lcs[Char]
+
+  "the lcs of an empty sequence and another sequence" should "be the empty sequence" in {
+
+    val lcs1 = lcsImpl.lcs("", "abcdef")
+
+    lcs1 should be(Nil)
+
+    val lcs2 = lcsImpl.lcs("abcdef", "")
+
+    lcs2 should be(Nil)
+
+  }
+
+  "the lcs of two equal strings" should "be the strings" in {
+
+    val str = "abcde"
+    val lcs = lcsImpl.lcs(str, str)
+    lcs should be(List(0 -> 0, 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4))
+
+  }
+
+  "the lcs of a string and a prefix" should "be the prefix" in {
+
+    val str = "abcdef"
+    val prefix = "abc"
+    val lcs1 = lcsImpl.lcs(str, prefix)
+
+    lcs1 should be(List(0 -> 0, 1 -> 1, 2 -> 2))
+
+    val lcs2 = lcsImpl.lcs(prefix, str)
+
+    lcs2 should be(List(0 -> 0, 1 -> 1, 2 -> 2))
+
+  }
+
+  "the lcs of two strings with no common characters " should "be empty" in {
+
+    val str1 = "abcdef"
+    val str2 = "ghijkl"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(Nil)
+  }
+
+  "the lcs of two strings" should "be correctly computed when one is in the middle of the other one" in {
+
+    val str1 = "abcdefgh"
+    val str2 = "bdeg"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(List(1 -> 0, 3 -> 1, 4 -> 2, 6 -> 3))
+  }
+
+  it should "be correctly computed with a repeated character in common" in {
+
+    val str1 = "abcbdbebf"
+    val str2 = "bbbb"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(List(1 -> 0, 3 -> 1, 5 -> 2, 7 -> 3))
+  }
+
+  it should "be correctly computed with non unique characters" in {
+
+    val str1 = "abcdabcd"
+    val str2 = "gabhakbf"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(List(0 -> 1, 1 -> 2, 4 -> 4, 5 -> 6))
+  }
+
+  it should "be correctly computed when both sequences have a common prefix and suffix" in {
+
+    val str1 = "abctotodef"
+    val str2 = "abctatatadef"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(List(0 -> 0, 1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 7 -> 9, 8 -> 10, 9 -> 11))
+
+  }
+
+}

--- a/src/test/scala/gnieh/diffson/TestPatience.scala
+++ b/src/test/scala/gnieh/diffson/TestPatience.scala
@@ -1,0 +1,10 @@
+package gnieh.diffson
+package test
+
+import org.scalatest._
+
+class TestPatience extends TestLcs {
+
+  val lcsImpl = new Patience[Char]
+
+}


### PR DESCRIPTION
patience diff algorithm is not always good at finding lcs when there is no common unique lines between files.
Falling back to a classic dynamic lcs algorithm in this case allows to get better LCS and then diffs.
