### PR TITLE
[fix #7] Diff with string

### DIFF
--- a/src/main/scala/gnieh/diffson/JsonPatch.scala
+++ b/src/main/scala/gnieh/diffson/JsonPatch.scala
@@ -28,13 +28,8 @@ final case class JsonPatch(ops: List[Operation])(implicit pointer: JsonPointer) 
     JsArray(ops.map(_.toJson).toVector)
 
   /** Applies this patch to the given Json valued and returns the patched value */
-  def apply(json: String, compacted: Boolean = false): String = {
-    val patched = apply(JsonParser(json))
-    if (compacted)
-      patched.compactPrint
-    else
-      patched.prettyPrint
-  }
+  def apply(json: String): String =
+    apply(JsonParser(json)).compactPrint
 
   /** Applies this patch to the given Json value, and returns the patched value */
   def apply(value: JsValue): JsValue =
@@ -83,13 +78,8 @@ sealed abstract class Operation {
   def toJson: JsObject
 
   /** Applies this operation to the given Json value */
-  def apply(json: String, compacted: Boolean = false)(implicit pointer: JsonPointer): String = {
-    val patched = apply(JsonParser(json))
-    if (compacted)
-      patched.compactPrint
-    else
-      patched.prettyPrint
-  }
+  def apply(json: String): String =
+    apply(JsonParser(json)).compactPrint
 
   /** Applies this operation to the given Json value */
   def apply(value: JsValue)(implicit pointer: JsonPointer): JsValue = action(value, path, Nil)

--- a/src/test/scala/gnieh/diffson/TestJsonDiff.scala
+++ b/src/test/scala/gnieh/diffson/TestJsonDiff.scala
@@ -116,4 +116,15 @@ class TestJsonDiff extends FlatSpec with ShouldMatchers {
     diff(json1, json2)(json1) should be(json2)
   }
 
+  "applying a diff to strings" should "provide a correct string representation" in {
+    val json1 = """{
+                   |  "a": 1,
+                   |  "b": true,
+                   |  "c": "test"
+                   |}""".stripMargin
+    val json2 = """{"a":6,"c":"test2","d":false}""".stripMargin
+    val json3 = JsonDiff.diff(json1, json2)(json1)
+    json3 should be(json2)
+  }
+
 }


### PR DESCRIPTION
The `compacted` parameter does not make much sense and, moreover,
prevents spray-json to work correctly.
Remove it makes no harm and makes it work again.