### PR TITLE
Wrong base index is fixed in array diff routine, ScalaCheck test case is added.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,6 +47,7 @@ object DiffsonBuild extends Build {
 
   lazy val dependencies = Seq(
     "org.scalatest" %% "scalatest" % "2.2.0" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
     "io.spray" %%  "spray-json" % "1.3.1"
   )
 

--- a/src/main/scala/gnieh/diffson/JsonDiff.scala
+++ b/src/main/scala/gnieh/diffson/JsonDiff.scala
@@ -142,7 +142,7 @@ class JsonDiff(lcsalg: Lcs[JsValue]) {
           remove(idx1 + shift1, until - 1 + shift1) reverse_::: acc)
       case (v1 :: tl1, v2 :: tl2) =>
         // values are different, recursively compute the diff of these values
-        loop(tl1, tl2, idx1 + 1, shift1, idx2 + 1, lcs, diff(v1, v2, path ::: List(idx1.toString)) reverse_::: acc)
+        loop(tl1, tl2, idx1 + 1, shift1, idx2 + 1, lcs, diff(v1, v2, path ::: List((idx1 + shift1).toString)) reverse_::: acc)
       case (_, Nil) =>
         // all subsequent values in arr1 were removed
         remove(idx1 + shift1, idx1 + arr1.size - 1 + shift1) reverse_::: acc

--- a/src/test/scala/gnieh/diffson/TestArrayDiff.scala
+++ b/src/test/scala/gnieh/diffson/TestArrayDiff.scala
@@ -1,0 +1,15 @@
+package gnieh.diffson
+package test
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import spray.json._
+
+object TestArrayDiff extends Properties("TestArrayDiff") {
+  import DefaultJsonProtocol._
+  property("arrayDiff") = forAll {
+    (a: Seq[Int], b: Seq[Int]) =>
+      val p = JsonDiff.diff(a, b)
+      p(a) == b
+  }
+}


### PR DESCRIPTION
Subsequent array operations (add/remove/replace) use wrong element indices.

This simple test case will fail:

```scala
val a = Array(1,2,3).toJson
val b = Array(2,4).toJson
val p = JsonDiff.diff(a,b)
p(a)
```