### PR TITLE
[fix #12] Do not reverse diff on object values

### DIFF
--- a/src/main/scala/gnieh/diffson/JsonDiff.scala
+++ b/src/main/scala/gnieh/diffson/JsonDiff.scala
@@ -68,9 +68,9 @@ class JsonDiff(lcsalg: Lcs[JsValue]) {
         // the second field is not present in the first object
         associate(fields1, t2, (None, Some(f2)) :: acc)
       case (_, Nil) =>
-        fields1.map(Some(_) -> None) reverse_::: acc
+        fields1.map(Some(_) -> None) ::: acc
       case (Nil, _) =>
-        fields2.map(None -> Some(_)) reverse_::: acc
+        fields2.map(None -> Some(_)) ::: acc
     }
     @tailrec
     def fields(fs: List[(Option[(String, JsValue)], Option[(String, JsValue)])], acc: List[Operation]): List[Operation] = fs match {
@@ -79,7 +79,7 @@ class JsonDiff(lcsalg: Lcs[JsValue]) {
         fields(tl, acc)
       case (Some(f1), Some(f2)) :: tl =>
         // same field name, different values
-        fields(tl, diff(f1._2, f2._2, path :+ f1._1) reverse_::: acc)
+        fields(tl, diff(f1._2, f2._2, path :+ f1._1) ::: acc)
       case (Some(f1), None) :: tl =>
         // the field was deleted
         fields(tl, Remove(path :+ f1._1) :: acc)

--- a/src/test/scala/gnieh/diffson/TestJsonDiff.scala
+++ b/src/test/scala/gnieh/diffson/TestJsonDiff.scala
@@ -25,7 +25,7 @@ class TestJsonDiff extends FlatSpec with ShouldMatchers {
     val json4 = JsonParser("""{"a": 3, "b": {"a": true }}""")
     val json5 = JsonParser("""{"a": 3, "b": {"a": true, "b": 43}, "c": null}""")
     diff(json1, json2) should be(JsonPatch(Add("new", JsBoolean(false))))
-    diff(json1, json3) should be(JsonPatch(Add("new1", JsBoolean(false)), Add("new2", JsNull)))
+    diff(json1, json3) should be(JsonPatch(Add("new2", JsNull), Add("new1", JsBoolean(false))))
     diff(json4, json5) should be(JsonPatch(Add("b" :: "b", JsNumber(43)), Add("c", JsNull)))
   }
 
@@ -36,8 +36,14 @@ class TestJsonDiff extends FlatSpec with ShouldMatchers {
     val json4 = JsonParser("""{"a": 3, "b": {"a": true }}""")
     val json5 = JsonParser("""{"a": 3, "b": {"a": true, "b": 43}, "c": null}""")
     diff(json2, json1) should be(JsonPatch(Remove("old")))
-    diff(json3, json1) should be(JsonPatch(Remove("old1"), Remove("old2")))
+    diff(json3, json1) should be(JsonPatch(Remove("old2"), Remove("old1")))
     diff(json5, json4) should be(JsonPatch(Remove("b" :: "b"), Remove("c")))
+  }
+
+  it should "correctly handle array diffs in objects" in {
+    val json1 = JsonParser("""{"lbl": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}""")
+    val json2 = JsonParser("""{"lbl": [1, 4, 5, 11, 6, 7]}""")
+    diff(json1, json2) should be(JsonPatch(Remove("lbl" :: "2"), Remove("lbl" :: "1"), Add("lbl" :: "3", JsNumber(11)), Remove("lbl" :: "8"), Remove("lbl" :: "7"), Remove("lbl" :: "6")))
   }
 
   it should "contain a replace operation for each changed field value" in {


### PR DESCRIPTION
It makes no sense to reverse the order of diff operations computed on
values contained in objects. More than that, it makes array diffs crash
if the order ir reversed. Order in object does not matter, so just don't
reverse useless things, even though it is more efficient.