### PR TITLE
Fix serialization of JSON patches

### DIFF
--- a/src/main/scala/gnieh/diffson/pointer.scala
+++ b/src/main/scala/gnieh/diffson/pointer.scala
@@ -61,14 +61,10 @@ object / {
 }
 
 private case object Root extends Pointer {
-  override def toString =
-    "/"
+  override def toString = ""
 }
 
 private final case class Path(prefix: Pointer, elem: String) extends Pointer {
   override def toString =
-    prefix match {
-      case Root => f"/${elem.replace("~", "~0").replace("/", "~1")}"
-      case _    => f"${prefix}${elem.replace("~", "~0").replace("/", "~1")}"
-    }
+    s"${prefix}/${elem.replace("~", "~0").replace("/", "~1")}"
 }

--- a/src/test/resources/conformance/spec_tests.json
+++ b/src/test/resources/conformance/spec_tests.json
@@ -4,7 +4,7 @@
     "doc": { "q": { "bar": 2 } },
     "patch": [ {"op": "add", "path": "/a/b", "value": 1} ],
     "error":
-       "element a does not exist at path /"
+       "element a does not exist at path "
   },
 
   {
@@ -181,7 +181,7 @@
     "patch": [
   { "op": "add", "path": "/baz/bat", "value": "qux" }
 ],
-    "error": "element baz does not exist at path /"
+    "error": "element baz does not exist at path "
   },
 
  {

--- a/src/test/resources/conformance/tests.json
+++ b/src/test/resources/conformance/tests.json
@@ -52,8 +52,7 @@
     { "comment": "Toplevel scalar values OK?",
       "doc": "foo",
       "patch": [{"op": "replace", "path": "", "value": "bar"}],
-      "expected": "bar",
-      "disabled": true },
+      "expected": "bar" },
 
     { "comment": "Add, / target",
       "doc": {},
@@ -119,11 +118,11 @@
     { "comment": "test with bad number should fail",
       "doc": ["foo", "bar"],
       "patch": [{"op": "test", "path": "/1e0", "value": "bar"}],
-      "error": "element 1e0 does not exist at path /" },
+      "error": "element 1e0 does not exist at path " },
 
     { "doc": ["foo", "sil"],
       "patch": [{"op": "add", "path": "/bar", "value": 42}],
-      "error": "element bar does not exist at path /" },
+      "error": "element bar does not exist at path " },
 
     { "doc": ["foo", "sil"],
       "patch": [{"op": "add", "path": "/1", "value": ["bar", "baz"]}],
@@ -203,8 +202,7 @@
 
     { "comment": "Whole document",
       "doc": { "foo": 1 },
-      "patch": [{"op": "test", "path": "", "value": {"foo": 1}}],
-      "disabled": true },
+      "patch": [{"op": "test", "path": "", "value": {"foo": 1}}] },
 
     { "comment": "Empty-string element",
       "doc": { "": 1 },
@@ -285,12 +283,12 @@
     { "comment": "test remove with bad index should fail",
       "doc": [1, 2, 3, 4],
       "patch": [{"op": "remove", "path": "/1e0"}],
-      "error": "element 1e0 does not exist at path /" },
+      "error": "element 1e0 does not exist at path " },
 
     { "comment": "test replace with bad number should fail",
       "doc": [""],
       "patch": [{"op": "replace", "path": "/1e0", "value": false}],
-      "error": "element 1e0 does not exist at path /" },
+      "error": "element 1e0 does not exist at path " },
 
     { "comment": "test copy with bad number should fail",
       "doc": {"baz": [1,2,3], "bar": 1},
@@ -305,7 +303,7 @@
     { "comment": "test add with bad number should fail",
       "doc": ["foo", "sil"],
       "patch": [{"op": "add", "path": "/1e0", "value": "bar"}],
-      "error": "element 1e0 does not exist at path /" },
+      "error": "element 1e0 does not exist at path " },
 
     { "comment": "missing 'value' parameter to add",
       "doc": [ 1 ],

--- a/src/test/scala/gnieh/diffson/TestSerialization.scala
+++ b/src/test/scala/gnieh/diffson/TestSerialization.scala
@@ -35,7 +35,7 @@ class TestSerialization extends FlatSpec with ShouldMatchers {
                 |},{
                 |  "op":"move",
                 |  "from":"/d",
-                |  "path":"/f"
+                |  "path":"/f/g"
                 |}]""".stripMargin
 
   val patchRemember = """[{
@@ -62,7 +62,7 @@ class TestSerialization extends FlatSpec with ShouldMatchers {
                         |},{
                         |  "op":"move",
                         |  "from":"/d",
-                        |  "path":"/f"
+                        |  "path":"/f/g"
                         |}]""".stripMargin
 
   val parsed =
@@ -77,7 +77,7 @@ class TestSerialization extends FlatSpec with ShouldMatchers {
     Add(Pointer("c"), JsString("test2")),
     Test(Pointer("d"), JsBoolean(false)),
     Copy(Pointer("c"), Pointer("e")),
-    Move(Pointer("d"), Pointer("f"))
+    Move(Pointer("d"), Pointer("f", "g"))
   )
 
   val jsonRemember = JsonPatch(
@@ -86,7 +86,7 @@ class TestSerialization extends FlatSpec with ShouldMatchers {
     Add(Pointer("c"), JsString("test2")),
     Test(Pointer("d"), JsBoolean(false)),
     Copy(Pointer("c"), Pointer("e")),
-    Move(Pointer("d"), Pointer("f"))
+    Move(Pointer("d"), Pointer("f", "g"))
   )
 
   "a patch json" should "be correctly deserialized from a Json object" in {
@@ -105,7 +105,7 @@ class TestSerialization extends FlatSpec with ShouldMatchers {
     jsonRemember.toJson should be(parsedRemember)
   }
 
-  "a pacth" should "be applicable to a serializable Scala object if the shape is kept" in {
+  "a patch" should "be applicable to a serializable Scala object if the shape is kept" in {
     val json1 = Json(1, true, "test", List(1, 2, 4))
     val json2 = Json(10, false, "toto", List(1, 2, 3, 4, 5))
     val patch = JsonDiff.diff(json1, json2, false)


### PR DESCRIPTION
JSON pointers with more than one slash were being serialized incorrectly, e.g. "/a/b/c" -> "/abc", which meant that a serialized JSON patch could not be deserialized and applied to a JSON value.