### PR TITLE
Circe support (fix #33)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val diffson = project.in(file("."))
   .settings(
     name := "diffson",
     packagedArtifacts := Map())
-  .aggregate(core, sprayJson, playJson)
+  .aggregate(core, sprayJson, playJson, circe)
 
 lazy val core = project.in(file("core"))
   .enablePlugins(SbtOsgi, ScoverageSbtPlugin)
@@ -71,6 +71,23 @@ lazy val playJson = project.in(file("playJson"))
       "Bundle-Name" -> "Gnieh Diffson Play! Json"
     ),
     OsgiKeys.bundleSymbolicName := "org.gnieh.diffson.play")
+  .dependsOn(core % "test->test;compile->compile")
+
+val circeVersion = "0.6.0"
+lazy val circe = project.in(file("circe"))
+  .enablePlugins(SbtOsgi, ScoverageSbtPlugin)
+  .settings(commonSettings: _*)
+  .settings(
+    name := "diffson-circe",
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core"    % circeVersion,
+      "io.circe" %% "circe-parser"  % circeVersion,
+      "io.circe" %% "circe-generic" % circeVersion % "test"
+    ),
+    OsgiKeys.additionalHeaders := Map (
+      "Bundle-Name" -> "Gnieh Diffson Circe"
+    ),
+    OsgiKeys.bundleSymbolicName := "org.gnieh.diffson.circe")
   .dependsOn(core % "test->test;compile->compile")
 
 lazy val publishSettings = Seq(

--- a/circe/src/main/scala/gnieh/diffson/CirceInstance.scala
+++ b/circe/src/main/scala/gnieh/diffson/CirceInstance.scala
@@ -1,0 +1,185 @@
+/*
+* This file is part of the diffson project.
+* Copyright (c) 2016 Lucas Satabin
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.diffson
+
+import cats.{ Apply, FlatMap }
+import cats.implicits._
+import io.circe._
+import io.circe.Decoder.Result
+import io.circe.syntax._
+
+object circe extends CirceInstance
+
+class CirceInstance extends DiffsonInstance[Json] {
+
+  object DiffsonProtocol extends DiffsonProtocol
+
+  trait DiffsonProtocol {
+
+    implicit val pointerEncoder: Encoder[Pointer] =
+      Encoder[String].contramap(_.toString)
+
+    implicit def pointerDecoder(implicit pointer: JsonPointer): Decoder[Pointer] =
+      Decoder[String].emap { s =>
+        Either.catchNonFatal(pointer.parse(s))
+          .leftMap(_.getMessage)
+      }
+
+    implicit val operationEncoder: Encoder[Operation] =
+      new Encoder[Operation] {
+        override def apply(op: Operation): Json = op match {
+          case Add(path, value) =>
+            Json.obj(
+              "op" -> Json.fromString("add"),
+              "path" -> Json.fromString(path.toString),
+              "value" -> value
+            )
+          case Remove(path, None) =>
+            Json.obj(
+              "op" -> Json.fromString("remove"),
+              "path" -> Json.fromString(path.toString)
+            )
+          case Remove(path, Some(old)) =>
+            Json.obj(
+              "op" -> Json.fromString("remove"),
+              "path" -> Json.fromString(path.toString),
+              "old" -> old
+            )
+          case Replace(path, value, None) =>
+            Json.obj(
+              "op" -> Json.fromString("replace"),
+              "path" -> Json.fromString(path.toString),
+              "value" -> value
+            )
+          case Replace(path, value, Some(old)) =>
+            Json.obj(
+              "op" -> Json.fromString("replace"),
+              "path" -> Json.fromString(path.toString),
+              "value" -> value,
+              "old" -> old
+            )
+          case Move(from, path) =>
+            Json.obj(
+              "op" -> Json.fromString("move"),
+              "from" -> Json.fromString(from.toString),
+              "path" -> Json.fromString(path.toString)
+            )
+          case Copy(from, path) =>
+            Json.obj(
+              "op" -> Json.fromString("copy"),
+              "from" -> Json.fromString(from.toString),
+              "path" -> Json.fromString(path.toString)
+            )
+          case Test(path, value) =>
+            Json.obj(
+              "op" -> Json.fromString("test"),
+              "path" -> Json.fromString(path.toString),
+              "value" -> value
+            )
+        }
+      }
+
+    implicit def operationDecoder(implicit pointer: JsonPointer): Decoder[Operation] =
+      new Decoder[Operation] {
+
+        private val A = Apply[Result]
+        private val F = FlatMap[Result]
+
+        override def apply(c: HCursor): Result[Operation] =
+          F.flatMap(c.get[String]("op").leftMap(_.withMessage("missing 'op' field"))) {
+            case "add" =>
+              A.map2(c.get[Pointer]("path"), c.get[Json]("value"))(Add)
+                .leftMap(_.withMessage("missing 'path' or 'value' field"))
+            case "remove" =>
+              A.map2(c.get[Pointer]("path"), c.get[Option[Json]]("old"))(Remove)
+                .leftMap(_.withMessage("missing 'path' or 'old' field"))
+            case "replace" =>
+              A.map3(c.get[Pointer]("path"), c.get[Json]("value"), c.get[Option[Json]]("old"))(Replace)
+                .leftMap(_.withMessage("missing 'path' or 'value' field"))
+            case "move" =>
+              A.map2(c.get[Pointer]("from"), c.get[Pointer]("path"))(Move(_, _))
+                .leftMap(_.withMessage("missing 'from' or 'path' field"))
+            case "copy" =>
+              A.map2(c.get[Pointer]("from"), c.get[Pointer]("path"))(Copy(_, _))
+                .leftMap(_.withMessage("missing 'from' or 'path' field"))
+            case "test" =>
+              A.map2(c.get[Pointer]("path"), c.get[Json]("value"))(Test(_, _))
+                .leftMap(_.withMessage("missing 'path' or 'value' field"))
+            case other =>
+              Left(DecodingFailure(s"""Unknown operation "$other"""", c.history))
+          }
+      }
+
+    implicit def jsonPatchEncoder: Encoder[JsonPatch] =
+      Encoder[List[Json]].contramap(_.ops.map(_.asJson))
+
+    implicit def jsonPatchDecoder(implicit pointer: JsonPointer): Decoder[JsonPatch] =
+      new Decoder[JsonPatch] {
+
+        private val F = FlatMap[Result]
+
+        override def apply(c: HCursor): Result[JsonPatch] =
+          F.flatMap(c.as[List[Json]]) { list =>
+            F.map(list.traverse(_.as[Operation]))(JsonPatch(_))
+          }
+      }
+  }
+
+  object provider extends JsonProvider {
+
+    type Marshaller[T] = Encoder[T]
+    type Unmarshaller[T] = Decoder[T]
+
+    val JsNull: Json =
+      io.circe.Json.Null
+
+    def applyArray(elems: Vector[Json]): Json =
+      io.circe.Json.fromValues(elems)
+
+    def applyObject(fields: Map[String, Json]): Json =
+      io.circe.Json.fromFields(fields)
+
+    def compactPrint(value: Json): String =
+      value.noSpaces
+
+    def marshall[T: Marshaller](value: T): Json =
+      implicitly[Marshaller[T]].apply(value)
+
+    def unmarshall[T: Unmarshaller](value: Json): T =
+      implicitly[Unmarshaller[T]].apply(value.hcursor).valueOr { e =>
+        throw new DiffsonException(e.message)
+      }
+
+    def parseJson(s: String): Json =
+      io.circe.jawn.parse(s).valueOr(throw _)
+
+    implicit val patchMarshaller: Marshaller[JsonPatch] =
+      DiffsonProtocol.jsonPatchEncoder
+
+    implicit val patchUnmarshaller: Unmarshaller[JsonPatch] =
+      DiffsonProtocol.jsonPatchDecoder
+
+    def prettyPrint(value: Json): String =
+      value.spaces2
+
+    def unapplyArray(value: Json): Option[Vector[Json]] =
+      value.asArray.map(_.toVector)
+
+    def unapplyObject(value: Json): Option[Map[String, Json]] =
+      value.asObject.map(_.toMap)
+  }
+}

--- a/circe/src/test/scala/gnieh/diffson/circe/TestArrayDiff.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestArrayDiff.scala
@@ -1,0 +1,5 @@
+package gnieh.diffson
+package test
+package circe
+
+class CirceTestArrayDiff extends TestArrayDiff[io.circe.Json, CirceInstance](gnieh.diffson.circe) with TestProtocol

--- a/circe/src/test/scala/gnieh/diffson/circe/TestJsonDiff.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestJsonDiff.scala
@@ -1,0 +1,5 @@
+package gnieh.diffson
+package test
+package circe
+
+class CirceJsonDiff extends TestJsonDiff[io.circe.Json, CirceInstance](gnieh.diffson.circe) with TestProtocol

--- a/circe/src/test/scala/gnieh/diffson/circe/TestJsonPatch.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestJsonPatch.scala
@@ -1,0 +1,5 @@
+package gnieh.diffson
+package test
+package circe
+
+class CirceTestJsonPatch extends TestJsonPatch[io.circe.Json, CirceInstance](gnieh.diffson.circe) with TestProtocol

--- a/circe/src/test/scala/gnieh/diffson/circe/TestJsonPointer.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestJsonPointer.scala
@@ -1,0 +1,5 @@
+package gnieh.diffson
+package test
+package circe
+
+class CirceTestJsonPointer extends TestJsonPointer[io.circe.Json, CirceInstance](gnieh.diffson.circe) with TestProtocol

--- a/circe/src/test/scala/gnieh/diffson/circe/TestProtocol.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestProtocol.scala
@@ -1,0 +1,18 @@
+package gnieh.diffson
+package test
+package circe
+
+import io.circe._
+import io.circe.generic.semiauto._
+
+trait TestProtocol {
+  implicit def intSeqMarshaller: Encoder[Seq[Int]] = Encoder.encodeTraversableOnce[Int, Seq]
+  implicit def intSeqUnmarshaller: Decoder[Seq[Int]] = Decoder[List[Int]].map(_.toSeq)
+  implicit def boolMarshaller: Encoder[Boolean] = Encoder.encodeBoolean
+  implicit def boolUnmarshaller: Decoder[Boolean] = Decoder.decodeBoolean
+  implicit def intMarshaller: Encoder[Int] = Encoder.encodeInt
+  implicit def intUnmarshaller: Decoder[Int] = Decoder.decodeInt
+  implicit def stringMarshaller: Encoder[String] = Encoder.encodeString
+  implicit def testJsonMarshaller: Encoder[test.Json] = deriveEncoder[test.Json]
+  implicit def testJsonUnmarshaller: Decoder[test.Json] = deriveDecoder[test.Json]
+}

--- a/circe/src/test/scala/gnieh/diffson/circe/TestSerialization.scala
+++ b/circe/src/test/scala/gnieh/diffson/circe/TestSerialization.scala
@@ -1,0 +1,7 @@
+package gnieh.diffson
+package test
+package circe
+
+import io.circe._
+
+class CirceTestSerialization extends TestSerialization[Json, CirceInstance](gnieh.diffson.circe) with TestProtocol

--- a/circe/src/test/scala/gnieh/diffson/conformance/CirceConformance.scala
+++ b/circe/src/test/scala/gnieh/diffson/conformance/CirceConformance.scala
@@ -1,0 +1,57 @@
+/*
+* This file is part of the diffson project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.diffson
+package conformance
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import cats.implicits._
+
+import scala.io.Source
+
+class CirceConformance extends TestRfcConformance[Json, CirceInstance](circe) {
+
+  import circe._
+
+  // [[io.circe.Json.JArray]] is private
+  type JsArray = io.circe.Json
+
+  implicit lazy val successConformanceTestUnmarshaller: Decoder[SuccessConformanceTest] =
+    deriveDecoder[SuccessConformanceTest]
+
+  implicit lazy val errorConformanceTestUnmarshaller: Decoder[ErrorConformanceTest] =
+    deriveDecoder[ErrorConformanceTest]
+
+  implicit lazy val commentConformanceTestUnMarshaller: Decoder[CommentConformanceTest] =
+    deriveDecoder[CommentConformanceTest]
+
+  implicit lazy val conformanceTestUnmarshaller: Decoder[ConformanceTest] = Decoder.instance[ConformanceTest] { c: HCursor =>
+    val fields = c.fieldSet.getOrElse(Set())
+    if (fields contains "error")
+      c.as[ErrorConformanceTest]
+    else if (fields contains "doc")
+      c.as[SuccessConformanceTest]
+    else if (fields == Set("comment"))
+      c.as[CommentConformanceTest]
+    else
+      Left[DecodingFailure, ConformanceTest](DecodingFailure(f"Test record expected but got ${c.top.spaces2}", Nil))
+  }
+
+  def load(path: String): List[ConformanceTest] =
+    io.circe.jawn.decode[List[ConformanceTest]](Source.fromURL(getClass.getResource(path)).mkString).valueOr(throw _)
+
+}


### PR DESCRIPTION
Added basic circe support. It's copied from my working codebase but it'd be better to have generic test suite for every supported JSON lib.
