### PR TITLE
Extend RootJsonFormat instead of JsonFormat for objects and arrays.

### DIFF
--- a/src/main/scala/gnieh/diffson/sprayJson/package.scala
+++ b/src/main/scala/gnieh/diffson/sprayJson/package.scala
@@ -37,8 +37,8 @@ package object sprayJson extends DiffsonInstance[JsValue] {
 
       }
 
-    implicit def OperationFormat(implicit pointer: JsonPointer): JsonFormat[Operation] =
-      new JsonFormat[Operation] {
+    implicit def OperationFormat(implicit pointer: JsonPointer): RootJsonFormat[Operation] =
+      new RootJsonFormat[Operation] {
 
         def write(op: Operation): JsObject =
           op match {
@@ -141,8 +141,8 @@ package object sprayJson extends DiffsonInstance[JsValue] {
         }
       }
 
-    implicit def JsonPatchFormat(implicit pointer: JsonPointer): JsonFormat[JsonPatch] =
-      new JsonFormat[JsonPatch] {
+    implicit def JsonPatchFormat(implicit pointer: JsonPointer): RootJsonFormat[JsonPatch] =
+      new RootJsonFormat[JsonPatch] {
 
         def write(patch: JsonPatch): JsArray =
           JsArray(patch.ops.map(_.toJson).toVector)


### PR DESCRIPTION
Spray distinguishes between `RootJsonFormat` (for types that serialize to a JSON object or array) and `JsonFormat` (for types that serialize to any JSON type, including invalid root types like string).  This PR makes `JsonPatch` and `Operation` serializable as a root JSON object.

More info here:
https://github.com/spray/spray-json#jsonformat-vs-rootjsonformat

Without this change, it is not possible to use `JsonPatch` in some desirable scenarios, such as in `entity(as[JsonPatch])` in an Akka HTTP route.