### PR TITLE
remove unecessary toVector conversion

### DIFF
--- a/circe/src/main/scala/gnieh/diffson/CirceInstance.scala
+++ b/circe/src/main/scala/gnieh/diffson/CirceInstance.scala
@@ -177,7 +177,7 @@ class CirceInstance extends DiffsonInstance[Json] {
       value.spaces2
 
     def unapplyArray(value: Json): Option[Vector[Json]] =
-      value.asArray.map(_.toVector)
+      value.asArray
 
     def unapplyObject(value: Json): Option[Map[String, Json]] =
       value.asObject.map(_.toMap)


### PR DESCRIPTION
since circe 0.7.0 Json arrays are represented by Vectors