### PR TITLE
Optimized LCS implementations for big arrays.

### DIFF
--- a/core/src/main/scala/gnieh/diffson/HashedLcs.scala
+++ b/core/src/main/scala/gnieh/diffson/HashedLcs.scala
@@ -1,0 +1,30 @@
+package gnieh.diffson
+
+import gnieh.diffson.HashedLcs.Hashed
+
+/** Speeds up LCS computations by pre-computing hashes for all objects.
+ *  Very useful for objects that recompute hashCodes on each invocation.
+ *
+ *  @param delegate Decorated LCS implementation.
+ */
+class HashedLcs[T](delegate: Lcs[Hashed[T]]) extends Lcs[T] {
+  override def lcs(seq1: Seq[T], seq2: Seq[T], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)] = {
+    // wrap all values and delegate to proper implementation
+    delegate.lcs(seq1.map(x => new Hashed[T](x)), seq2.map(x => new Hashed[T](x)), low1, high1, low2, high2)
+  }
+}
+
+object HashedLcs {
+  /** Wraps provided value together with its hashCode. Equals is overridden to first
+   *  check hashCode and then delegate to the wrapped value.
+   *
+   *  @param value wrapped value
+   */
+  class Hashed[T](val value: T) {
+    override val hashCode: Int = value.hashCode()
+    override def equals(other: Any): Boolean = other match {
+      case that: Hashed[_] if that.hashCode == hashCode => value.equals(that.value)
+      case _ => false
+    }
+  }
+}

--- a/core/src/main/scala/gnieh/diffson/JsonDiffSupport.scala
+++ b/core/src/main/scala/gnieh/diffson/JsonDiffSupport.scala
@@ -26,7 +26,7 @@ trait JsonDiffSupport[JsValue] {
    *
    *  @author Lucas Satabin
    */
-  object JsonDiff extends JsonDiff(new Patience[JsValue])
+  object JsonDiff extends JsonDiff(new HashedLcs[JsValue](new Patience[HashedLcs.Hashed[JsValue]]()))
 
   /** Methods to compute diffs between two Json values
    *

--- a/core/src/main/scala/gnieh/diffson/Patience.scala
+++ b/core/src/main/scala/gnieh/diffson/Patience.scala
@@ -109,6 +109,12 @@ class Patience[T](withFallback: Boolean = true) extends Lcs[T] {
     }
   }
 
+  /** Checks if two sequences have at least one common element */
+  private def haveCommonElements(s1: Seq[T], s2: Seq[T]): Boolean = {
+    val s2Set = s2.toSet
+    s1.exists(s2Set)
+  }
+
   /** Computes the longest common subsequence between both sequences.
    *  It is encoded as the list of common indices in the first and the second sequence.
    */
@@ -129,6 +135,9 @@ class Patience[T](withFallback: Boolean = true) extends Lcs[T] {
       // the first sequence is a prefix of the second one
       // the lcs is the first sequence
       seq1.indices.map(i => (i + low1, i + low2)).toList
+    } else if (!haveCommonElements(seq1, seq2)) {
+      // sequences have no common elements
+      Nil
     } else {
       // fill the holes with possibly common (not unique) elements
       def loop(low1: Int, low2: Int, high1: Int, high2: Int, acc: List[(Int, Int)]): List[(Int, Int)] =


### PR DESCRIPTION
Last week I encountered a performance problem when comparing large objects (10 MB). The process took more than 1h (yes, 60m).  After profiling I managed to find a few problems and fixed them. After optimizations the diff computes in ~1s on cold VM.

Important: I am using play-json and used only that implemenation for tests.

Test case:
Both of my jsons contain a large array (>10000). There are no common elements - all objects were changed. JsonDiif decided to first run Patience alg for LCS and then fallback to Dynamic impl. LCS computation took more than 99% of the process.

Changes:
1. Added check in Patience LCS to return immediatelly if there are no common elements.
    This completely avoids very long computations that occur without this check.
2. Added HashedLcs
    JsValues are constantly compared in both LCS implementations - which is costly. HashedLcs decorates LCS implementations and precomputes and stores all hashes. This fix has a nice synenergy with 1.
3. DynamicProgLcs 
    The reason why DynamicProgLcs was so slow is in the following loop:
```
for {
   i <- 0 until middle1.size
   j <- 0 until middle2.size
} if (middle1(i) == middle2(j))
     lengths(i + 1)(j + 1) = lengths(i)(j) + 1
  else
     lengths(i + 1)(j + 1) = math.max(lengths(i + 1)(j), lengths(i)(j + 1))
```
   `middle1` and `middle2` are actually Lists, so `apply(Int): T` is O(N). I added a conversion to IndexedSeq.

4. `0 until middle1.size` - this is a wild guess, but such construct may be too heavy for this, performance-critical code. So I rewrote this loop to 2 nested whiles.