### PR TITLE
Switch to latest Circe version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val playJson = project.in(file("playJson"))
     OsgiKeys.bundleSymbolicName := "org.gnieh.diffson.play")
   .dependsOn(core % "test->test;compile->compile")
 
-val circeVersion = "0.9.3"
+val circeVersion = "0.10.0"
 lazy val circe = project.in(file("circe"))
   .enablePlugins(SbtOsgi, ScoverageSbtPlugin)
   .settings(commonSettings: _*)

--- a/circe/src/test/scala/gnieh/diffson/conformance/CirceConformance.scala
+++ b/circe/src/test/scala/gnieh/diffson/conformance/CirceConformance.scala
@@ -40,7 +40,7 @@ class CirceConformance extends TestRfcConformance[Json, CirceInstance](circe) {
     deriveDecoder[CommentConformanceTest]
 
   implicit lazy val conformanceTestUnmarshaller: Decoder[ConformanceTest] = Decoder.instance[ConformanceTest] { c: HCursor =>
-    val fields = c.fieldSet.getOrElse(Set())
+    val fields = c.keys.fold(Set.empty[String])(_.toSet)
     if (fields contains "error")
       c.as[ErrorConformanceTest]
     else if (fields contains "doc")


### PR DESCRIPTION
.fieldSet has been deprecated in favor of .keys since 0.9.0, and has
since been removed.
https://github.com/circe/circe/pull/696