### PR TITLE
Make it possible to remember old values

### DIFF
--- a/circe/src/main/scala/diffson/circe/package.scala
+++ b/circe/src/main/scala/diffson/circe/package.scala
@@ -65,11 +65,22 @@ package object circe {
           "op" -> Json.fromString("add"),
           "path" -> Json.fromString(path.show),
           "value" -> value)
-      case Remove(path) =>
+      case Remove(path, Some(old)) =>
+        Json.obj(
+          "op" -> Json.fromString("remove"),
+          "path" -> Json.fromString(path.show),
+          "old" -> old)
+      case Remove(path, None) =>
         Json.obj(
           "op" -> Json.fromString("remove"),
           "path" -> Json.fromString(path.show))
-      case Replace(path, value) =>
+      case Replace(path, value, Some(old)) =>
+        Json.obj(
+          "op" -> Json.fromString("replace"),
+          "path" -> Json.fromString(path.show),
+          "value" -> value,
+          "old" -> old)
+      case Replace(path, value, None) =>
         Json.obj(
           "op" -> Json.fromString("replace"),
           "path" -> Json.fromString(path.show),
@@ -103,10 +114,10 @@ package object circe {
             A.map2(c.get[Pointer]("path"), c.get[Json]("value"))(Add[Json])
               .leftMap(_.copy(history = Nil, message = "missing 'path' or 'value' field"))
           case "remove" =>
-            A.map(c.get[Pointer]("path"))(Remove[Json])
+            A.map2(c.get[Pointer]("path"), c.get[Option[Json]]("old"))(Remove[Json])
               .leftMap(_.copy(history = Nil, message = "missing 'path' field"))
           case "replace" =>
-            A.map2(c.get[Pointer]("path"), c.get[Json]("value"))(Replace[Json] _)
+            A.map3(c.get[Pointer]("path"), c.get[Json]("value"), c.get[Option[Json]]("old"))(Replace[Json] _)
               .leftMap(_.copy(history = Nil, message = "missing 'path' or 'value' field"))
           case "move" =>
             A.map2(c.get[Pointer]("from"), c.get[Pointer]("path"))(Move[Json])

--- a/core/src/main/scala/diffson/jsonpatch/JsonPatch.scala
+++ b/core/src/main/scala/diffson/jsonpatch/JsonPatch.scala
@@ -84,7 +84,7 @@ case class Add[Json: Jsony](path: Pointer, value: Json) extends Operation[Json] 
 }
 
 /** Remove the pointed element */
-case class Remove[Json: Jsony](path: Pointer) extends Operation[Json] {
+case class Remove[Json: Jsony](path: Pointer, old: Option[Json] = None) extends Operation[Json] {
 
   override protected[this] def action[F[_]](value: Json, pointer: Pointer, parent: Pointer)(implicit F: MonadError[F, Throwable]): F[Json] =
     (value, pointer) match {
@@ -112,7 +112,7 @@ case class Remove[Json: Jsony](path: Pointer) extends Operation[Json] {
 }
 
 /** Replace the pointed element by the given value */
-case class Replace[Json: Jsony](path: Pointer, value: Json) extends Operation[Json] {
+case class Replace[Json: Jsony](path: Pointer, value: Json, old: Option[Json] = None) extends Operation[Json] {
 
   override protected[this] def action[F[_]](original: Json, pointer: Pointer, parent: Pointer)(implicit F: MonadError[F, Throwable]): F[Json] =
     (original, pointer) match {

--- a/core/src/main/scala/diffson/jsonpatch/package.scala
+++ b/core/src/main/scala/diffson/jsonpatch/package.scala
@@ -24,8 +24,12 @@ import scala.language.higherKinds
 package object jsonpatch {
 
   object lcsdiff {
+    object remembering {
+      implicit def JsonDiffDiff[Json: Jsony: Lcs]: Diff[Json, JsonPatch[Json]] =
+        new JsonDiff[Json](true, true)
+    }
     implicit def JsonDiffDiff[Json: Jsony: Lcs]: Diff[Json, JsonPatch[Json]] =
-      new JsonDiff[Json](true)
+      new JsonDiff[Json](true, false)
   }
 
   object simplediff {
@@ -33,8 +37,12 @@ package object jsonpatch {
       def savedHashes = this
       def lcs(seq1: List[Json], seq2: List[Json], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)] = Nil
     }
+    object remembering {
+      implicit def JsonDiffDiff[Json: Jsony: Lcs]: Diff[Json, JsonPatch[Json]] =
+        new JsonDiff[Json](false, true)
+    }
     implicit def JsonDiffDiff[Json: Jsony]: Diff[Json, JsonPatch[Json]] =
-      new JsonDiff[Json](false)
+      new JsonDiff[Json](false, false)
   }
 
 }

--- a/playJson/src/main/scala/diffson/playJson/DiffsonProtocol.scala
+++ b/playJson/src/main/scala/diffson/playJson/DiffsonProtocol.scala
@@ -80,16 +80,16 @@ object DiffsonProtocol {
                   JsError("missing 'path' or 'value' field")
               }
             case JsString("remove") =>
-              fields.get("path") match {
-                case Some(JsString(path)) =>
-                  JsSuccess(Remove(Pointer.parse[JsResult](path).get))
+              (fields.get("path"), fields.get("old")) match {
+                case (Some(JsString(path)), old) =>
+                  JsSuccess(Remove(Pointer.parse[JsResult](path).get, old))
                 case _ =>
                   JsError("missing 'path' field")
               }
             case JsString("replace") =>
-              (fields.get("path"), fields.get("value")) match {
-                case (Some(JsString(path)), Some(value)) =>
-                  JsSuccess(Replace(Pointer.parse[JsResult](path).get, value))
+              (fields.get("path"), fields.get("value"), fields.get("old")) match {
+                case (Some(JsString(path)), Some(value), old) =>
+                  JsSuccess(Replace(Pointer.parse[JsResult](path).get, value, old))
                 case _ =>
                   JsError("missing 'path' or 'value' field")
               }
@@ -126,11 +126,22 @@ object DiffsonProtocol {
             "op" -> JsString("add"),
             "path" -> JsString(path.show),
             "value" -> value)
-        case Remove(path) =>
+        case Remove(path, Some(old)) =>
+          Json.obj(
+            "op" -> JsString("remove"),
+            "path" -> JsString(path.show),
+            "old" -> old)
+        case Remove(path, None) =>
           Json.obj(
             "op" -> JsString("remove"),
             "path" -> JsString(path.show))
-        case Replace(path, value) =>
+        case Replace(path, value, Some(old)) =>
+          Json.obj(
+            "op" -> JsString("replace"),
+            "path" -> JsString(path.show),
+            "value" -> value,
+            "old" -> old)
+        case Replace(path, value, None) =>
           Json.obj(
             "op" -> JsString("replace"),
             "path" -> JsString(path.show),

--- a/testkit/src/main/scala/diffson/TestJsonDiff.scala
+++ b/testkit/src/main/scala/diffson/TestJsonDiff.scala
@@ -141,4 +141,31 @@ abstract class TestJsonDiff[Json](implicit Json: Jsony[Json]) extends FlatSpec w
     json3 should be(json2)
   }
 
+  "a remembering diff" should "correctly add removed values in array diffs" in {
+    val json1 = parseJson("""{"lbl": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}""")
+    val json2 = parseJson("""{"lbl": [1, 4, 5, 11, 6, 7]}""")
+    import remembering._
+    diff(json1, json2) should be(JsonPatch(
+      Remove(Pointer("lbl", "2"), Some(3: Json)),
+      Remove(Pointer("lbl", "1"), Some(2: Json)),
+      Add(Pointer("lbl", "3"), 11: Json),
+      Remove(Pointer("lbl", "8"), Some(10: Json)),
+      Remove(Pointer("lbl", "7"), Some(9: Json)),
+      Remove(Pointer("lbl", "6"), Some(8: Json))))
+  }
+
+  it should "correctly add removed values in object diffs" in {
+    val json1 = parseJson("""{"a": 1, "b": true}""")
+    val json2 = parseJson("""{"a": 1}""")
+    import remembering._
+    diff(json1, json2) should be(JsonPatch(Remove(Pointer("b"), Some(true: Json))))
+  }
+
+  it should "correctly add replaced values in object diffs" in {
+    val json1 = parseJson("""{"a": 1, "b": false}""")
+    val json2 = parseJson("""{"a": 1, "b": "test"}""")
+    import remembering._
+    diff(json1, json2) should be(JsonPatch(Replace(Pointer("b"), "test": Json, Some(false: Json))))
+  }
+
 }


### PR DESCRIPTION
Remembering old values on `replace` and `remove` operations makes it
possible to invert patches generated by the diff algorithm.

This reintroduces the feature from diffson 3, that appeared with #21.