### PR TITLE
Fix simple diff with remember

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 val scala212 = "2.12.17"
 val scala213 = "2.13.9"
 val scala3 = "3.2.0"
@@ -13,7 +15,7 @@ ThisBuild / tlSonatypeUseLegacyHost := true
 
 ThisBuild / tlFatalWarnings := false
 
-ThisBuild / tlBaseVersion := "4.1"
+ThisBuild / tlBaseVersion := "4.2"
 
 ThisBuild / organization := "org.gnieh"
 ThisBuild / startYear := Some(2022)
@@ -41,6 +43,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.typelevel" %%% "cats-core" % "2.8.0",
       "org.scalatest" %%% "scalatest" % scalatestVersion % Test,
       "org.scalacheck" %%% "scalacheck" % scalacheckVersion % Test
+    ),
+    mimaBinaryIssueFilters ++= List(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "diffson.jsonpatch.package#simplediff#remembering.JsonDiffDiff")
     )
   )
 

--- a/core/src/main/scala/diffson/jsonpatch/package.scala
+++ b/core/src/main/scala/diffson/jsonpatch/package.scala
@@ -35,7 +35,7 @@ package object jsonpatch {
       def lcs(seq1: List[Json], seq2: List[Json], low1: Int, high1: Int, low2: Int, high2: Int): List[(Int, Int)] = Nil
     }
     object remembering {
-      implicit def JsonDiffDiff[Json: Jsony: Lcs]: Diff[Json, JsonPatch[Json]] =
+      implicit def JsonDiffDiff[Json: Jsony]: Diff[Json, JsonPatch[Json]] =
         new JsonDiff[Json](false, true)
     }
     implicit def JsonDiffDiff[Json: Jsony]: Diff[Json, JsonPatch[Json]] =

--- a/testkit/shared/src/main/scala/diffson/TestSimpleDiff.scala
+++ b/testkit/shared/src/main/scala/diffson/TestSimpleDiff.scala
@@ -20,15 +20,10 @@ package jsonpatch
 import simplediff._
 import jsonpointer._
 
-import cats._
-import cats.implicits._
-
-import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.util.Try
 
-import scala.language.implicitConversions
 import org.scalatest.matchers.should.Matchers
 
 abstract class TestSimpleDiff[Json](implicit val Json: Jsony[Json])
@@ -154,6 +149,14 @@ abstract class TestSimpleDiff[Json](implicit val Json: Jsony[Json])
     val json1 = parseJson("""{"a": 1, "b": false}""")
     val json2 = parseJson("""{"a": 1, "b": "test"}""")
     diff(json1, json2) should be(JsonPatch[Json](Replace(Pointer("b"), "test": Json)))
+  }
+
+  "a remembering diff" should "remember old values" in {
+    import diffson.jsonpatch.simplediff.remembering._
+    val json1 = parseJson("""{"a": 1, "b": false}""")
+    val json2 = parseJson("""{"a": 1, "b": "test"}""")
+
+    diff(json1, json2) should be(JsonPatch[Json](Replace(Pointer("b"), "test": Json, Some(false: Json))))
   }
 
 }


### PR DESCRIPTION
A simple diff does not need any LCS instance, even when remembering.

Fixes #275