### PR TITLE
Use 2.10.0-RC6 of Play! Json to enable Scala 3 build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,9 +72,7 @@ lazy val playJson = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
   .in(file("playJson"))
   .settings(commonSettings: _*)
-  .settings(name := "diffson-play-json",
-            libraryDependencies += "com.typesafe.play" %%% "play-json" % "2.9.3",
-            crossScalaVersions := Seq(scala212, scala213))
+  .settings(name := "diffson-play-json", libraryDependencies += "com.typesafe.play" %%% "play-json" % "2.10.0-RC6")
   .dependsOn(core, testkit % Test)
 
 val circeVersion = "0.14.3"

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,9 @@ lazy val playJson = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
   .in(file("playJson"))
   .settings(commonSettings: _*)
-  .settings(name := "diffson-play-json", libraryDependencies += "com.typesafe.play" %%% "play-json" % "2.10.0-RC6")
+  .settings(name := "diffson-play-json",
+            libraryDependencies += "com.typesafe.play" %%% "play-json" % "2.10.0-RC6",
+            tlVersionIntroduced := Map("3" -> "4.3.0"))
   .dependsOn(core, testkit % Test)
 
 val circeVersion = "0.14.3"


### PR DESCRIPTION
This RC is out since March and the best option to have something on Scala 3 as development seems pretty much stalled.

Having this would help fs2-data to jump to full Scala 3 support (and on the fly fix some build complications arising from the missing support now).