### PR TITLE
Optimization: Reuse Map when when building a Circe JsonObject

### DIFF
--- a/circe/shared/src/main/scala/diffson/circe/package.scala
+++ b/circe/shared/src/main/scala/diffson/circe/package.scala
@@ -42,7 +42,7 @@ package object circe {
       Json.fromValues(values)
 
     def makeObject(fields: Map[String, Json]): Json =
-      Json.fromFields(fields)
+      Json.fromJsonObject(JsonObject.fromMap(fields))
 
     def show(json: Json): String =
       json.noSpaces


### PR DESCRIPTION
Thank you for your recent optimization efforts :+1: 

Looking at my usage I found that most of the cost at runtime comes from the integration layer with Circe, more specifically the `apply` and `unapply` function for `JsObject` tend to allocate a lot.

This PR proposes to optimize the `JsObject.apply` by making Circe reuse the input fields `Map` instead of building a new one internally.

As a side effect, Circe will switch its internal representation to `MapAndVectorJsonObject` for its objects which would speed up the `JsObject.unapply` case.