### PR TITLE
Update libs for Scala Native 0.5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         scala: [2.12, 2.13, 3]
-        java: [temurin@11]
+        java: [temurin@17]
         project: [diffsonJVM, diffsonJS, diffsonNative]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -42,24 +42,24 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: scalaJSLink
@@ -74,11 +74,11 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -114,17 +114,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Download target directories (2.12, diffsonJVM)
@@ -247,7 +247,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -258,17 +258,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Submit Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,9 @@ ThisBuild / developers := List(
   tlGitHubDev("ybasket", "Yannick Heiber")
 )
 
+// use JDK 17
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
+
 // Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
 // has to include _native suffix due to https://github.com/sbt/sbt/issues/7140
 ThisBuild / libraryDependencySchemes +=

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 import com.typesafe.tools.mima.core._
 
 val scala212 = "2.12.20"
-val scala213 = "2.13.14"
-val scala3 = "3.3.3"
+val scala213 = "2.13.16"
+val scala3 = "3.3.6"
 
-val scalatestVersion = "3.2.18"
-val scalacheckVersion = "1.17.1"
+val scalatestVersion = "3.2.19"
+val scalacheckVersion = "1.18.1"
 
 ThisBuild / tlJdkRelease := Some(11)
 ThisBuild / scalaVersion := scala213
@@ -39,8 +39,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     name := "diffson-core",
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.11.0",
-      "org.typelevel" %%% "cats-core" % "2.10.0",
+      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.13.0",
+      "org.typelevel" %%% "cats-core" % "2.13.0",
       "org.scalatest" %%% "scalatest" % scalatestVersion % Test,
       "org.scalacheck" %%% "scalacheck" % scalacheckVersion % Test
     ),
@@ -57,7 +57,9 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings: _*)
   .settings(name := "diffson-testkit",
             libraryDependencies ++= Seq("org.scalatest" %%% "scalatest" % scalatestVersion,
-                                        "org.scalacheck" %%% "scalacheck" % scalacheckVersion))
+                                        "org.scalacheck" %%% "scalacheck" % scalacheckVersion),
+            // Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
+            libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_2.13" % "always")
   .dependsOn(core)
 
 lazy val sprayJson = crossProject(JVMPlatform)
@@ -74,12 +76,12 @@ lazy val playJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("playJson"))
   .settings(commonSettings: _*)
   .settings(name := "diffson-play-json",
-            libraryDependencies += "org.playframework" %%% "play-json" % "3.0.4",
+            libraryDependencies += "org.playframework" %%% "play-json" % "3.1.0-M3",
             tlVersionIntroduced := Map("3" -> "4.3.0"))
   .nativeSettings(tlVersionIntroduced := Map("2.12" -> "4.5.0", "2.13" -> "4.5.0", "3" -> "4.5.0"))
   .dependsOn(core, testkit % Test)
 
-val circeVersion = "0.14.8"
+val circeVersion = "0.14.14"
 lazy val circe = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .in(file("circe"))
@@ -93,7 +95,7 @@ lazy val circe = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .dependsOn(core, testkit % Test)
 
-val ujsonVersion = "3.1.4"
+val ujsonVersion = "3.3.1"
 lazy val ujson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .in(file("ujson"))

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,11 @@ ThisBuild / developers := List(
   tlGitHubDev("ybasket", "Yannick Heiber")
 )
 
+// Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
+// has to include _native suffix due to https://github.com/sbt/sbt/issues/7140
+ThisBuild / libraryDependencySchemes += 
+  "org.scala-native" %% "test-interface_native0.5" % VersionScheme.Always
+
 lazy val commonSettings = Seq(
   description := "Json diff/patch library",
   homepage := Some(url("https://github.com/gnieh/diffson"))
@@ -57,9 +62,7 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings: _*)
   .settings(name := "diffson-testkit",
             libraryDependencies ++= Seq("org.scalatest" %%% "scalatest" % scalatestVersion,
-                                        "org.scalacheck" %%% "scalacheck" % scalacheckVersion),
-            // Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
-            libraryDependencySchemes += "org.scala-native" % "test-interface_native0.5_2.13" % "always")
+                                        "org.scalacheck" %%% "scalacheck" % scalacheckVersion))
   .dependsOn(core)
 
 lazy val sprayJson = crossProject(JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / developers := List(
 
 // Silence binary compatibility warnings for test-interface in Scala Native 0.5.x series
 // has to include _native suffix due to https://github.com/sbt/sbt/issues/7140
-ThisBuild / libraryDependencySchemes += 
+ThisBuild / libraryDependencySchemes +=
   "org.scala-native" %% "test-interface_native0.5" % VersionScheme.Always
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ ThisBuild / crossScalaVersions := Seq(elems = scala212, scala213, scala3)
 
 ThisBuild / tlFatalWarnings := false
 
-ThisBuild / tlBaseVersion := "4.6"
+ThisBuild / tlBaseVersion := "5.0"
 
 ThisBuild / organization := "org.gnieh"
 ThisBuild / organizationName := "Diffson Project"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.3")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
This PR applies the minimal dependency update required to move diffson to Scala Native 0.5.x. It's blocking https://github.com/gnieh/fs2-data/pull/704 and some more libraries down stream