### PR TITLE
Fix stack overflow when diffing wide objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Test
+    name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [2.12, 2.13, 3]
         java: [temurin@11]
         project: [diffsonJVM, diffsonJS, diffsonNative]
@@ -38,6 +38,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -56,7 +59,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: scalaJSLink
@@ -71,11 +74,11 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
@@ -99,7 +102,7 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,6 +110,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -237,10 +243,10 @@ jobs:
 
   dependency-submission:
     name: Submit Dependencies
-    if: github.event_name != 'pull_request'
+    if: github.event.repository.fork == false && github.event_name != 'pull_request'
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -248,6 +254,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -272,7 +281,7 @@ jobs:
     name: Validate Steward Config
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ ThisBuild / crossScalaVersions := Seq(elems = scala212, scala213, scala3)
 
 ThisBuild / tlFatalWarnings := false
 
-ThisBuild / tlBaseVersion := "4.5"
+ThisBuild / tlBaseVersion := "4.6"
 
 ThisBuild / organization := "org.gnieh"
 ThisBuild / organizationName := "Diffson Project"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.tools.mima.core._
 
 val scala212 = "2.12.19"
-val scala213 = "2.13.12"
+val scala213 = "2.13.13"
 val scala3 = "3.3.3"
 
 val scalatestVersion = "3.2.18"

--- a/circe/shared/src/test/scala/diffson/circe/CirceTestObjectDiff.scala
+++ b/circe/shared/src/test/scala/diffson/circe/CirceTestObjectDiff.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Diffson Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package diffson.circe
 
 import diffson.jsonpatch.TestObjectDiff

--- a/circe/shared/src/test/scala/diffson/circe/CirceTestObjectDiff.scala
+++ b/circe/shared/src/test/scala/diffson/circe/CirceTestObjectDiff.scala
@@ -1,0 +1,6 @@
+package diffson.circe
+
+import diffson.jsonpatch.TestObjectDiff
+import io.circe.Json
+
+class CirceTestObjectDiff extends TestObjectDiff[Json]

--- a/core/src/main/scala/diffson/jsonpatch/JsonDiff.scala
+++ b/core/src/main/scala/diffson/jsonpatch/JsonDiff.scala
@@ -48,11 +48,14 @@ class JsonDiff[Json](diffArray: Boolean, rememberOld: Boolean)(implicit J: Jsony
       case (fld, value1) :: fields1 =>
         fields2.get(fld) match {
           case Some(value2) =>
-            Eval.defer(fieldsDiff(fields1, fields2 - fld, path)).flatMap(d => diff(value1, value2, path / fld).map(_ ++ d))
+            Eval
+              .defer(fieldsDiff(fields1, fields2 - fld, path))
+              .flatMap(d => diff(value1, value2, path / fld).map(_ ++ d))
           case None =>
             // field is not in the second object, delete it
-            Eval.defer(fieldsDiff(fields1, fields2, path)).map(
-              _.prepend(Remove(path / fld, if (rememberOld) Some(value1) else None)))
+            Eval
+              .defer(fieldsDiff(fields1, fields2, path))
+              .map(_.prepend(Remove(path / fld, if (rememberOld) Some(value1) else None)))
         }
       case Nil =>
         Eval.now(Chain.fromSeq(fields2.toList).map { case (fld, value) => Add(path / fld, value) })

--- a/core/src/main/scala/diffson/jsonpatch/JsonDiff.scala
+++ b/core/src/main/scala/diffson/jsonpatch/JsonDiff.scala
@@ -48,10 +48,10 @@ class JsonDiff[Json](diffArray: Boolean, rememberOld: Boolean)(implicit J: Jsony
       case (fld, value1) :: fields1 =>
         fields2.get(fld) match {
           case Some(value2) =>
-            fieldsDiff(fields1, fields2 - fld, path).flatMap(d => diff(value1, value2, path / fld).map(_ ++ d))
+            Eval.defer(fieldsDiff(fields1, fields2 - fld, path)).flatMap(d => diff(value1, value2, path / fld).map(_ ++ d))
           case None =>
             // field is not in the second object, delete it
-            fieldsDiff(fields1, fields2, path).map(
+            Eval.defer(fieldsDiff(fields1, fields2, path)).map(
               _.prepend(Remove(path / fld, if (rememberOld) Some(value1) else None)))
         }
       case Nil =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.6.7")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.8.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")

--- a/testkit/shared/src/main/scala/diffson/TestObjectDiff.scala
+++ b/testkit/shared/src/main/scala/diffson/TestObjectDiff.scala
@@ -1,0 +1,28 @@
+package diffson
+package jsonpatch
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import diffson.jsonpatch.JsonDiff
+import diffson.lcs.Patience
+
+abstract class TestObjectDiff[J](implicit J: Jsony[J]) extends AnyFlatSpec with Matchers {
+
+  implicit val lcsalg: Patience[J] = new Patience[J]
+
+  val diff = new JsonDiff[J](false, false)
+
+  "a wide object diffed with an empty one" should "not cause stack overflows" in {
+    val json1 = J.makeObject((1 to 10000).map(i => s"key$i" -> J.Null).toMap)
+    val json2 = J.makeObject(Map.empty)
+
+    diff.diff(json1, json2)
+  }
+
+  "a wide object diffed with itself" should "not cause stack overflows" in {
+    val json1 = J.makeObject((1 to 10000).map(i => s"key$i" -> J.Null).toMap)
+
+    diff.diff(json1, json1)
+  }
+
+}

--- a/testkit/shared/src/main/scala/diffson/TestObjectDiff.scala
+++ b/testkit/shared/src/main/scala/diffson/TestObjectDiff.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Diffson Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package diffson
 package jsonpatch
 


### PR DESCRIPTION
The recursive call is sadly not in tail position, so it does use stack when comparing sibling fields. This change suspends the recursive call within an `Eval`, which turns it into a stack safe version.

Without the change, the two added tests fail with a `StackOverflow`.